### PR TITLE
feat: add modal experience details to timeline

### DIFF
--- a/src/data/jobs.ts
+++ b/src/data/jobs.ts
@@ -1,62 +1,122 @@
 export interface Job {
-	dateRange: string;
-	title: string;
-	company: string;
-	description: string;
+        dateRange: string;
+        title: string;
+        company: string;
+        location?: string;
+        employmentType?: string;
+        summary?: string;
+        details?: string[];
+        skills?: string[];
 }
 
 export const jobs: Job[] = [
-	{
-		dateRange: "Sep 2025 - Dec 2025",
-		title: "Software Engineering Intern, Infrastructure",
-		company: "Super.com",
-		description: "",
-	},
-	{
-		dateRange: "Jan 2025 - May 2025",
-		title: "Fullstack Software Engineering Intern",
-		company: "Hamming AI (YC S24)",
-		description: "Built dynamically generated IVR state machines for AI voice agent testing, directly leading to new customers. Investigated and fixed critical Redis concurrency issues, reducing call error rate by 85%. Automated frontend and backend tests using GitHub Actions and scheduled jobs to catch regressions in CI/CD. Enabled third-party voice agents to integrate with the Hamming platform, unlocking new customers.",
-	},
-	{
-		dateRange: "Oct 2024 - Current",
-		title: "Member",
-		company: "Cohere For AI",
-		description: "",
-	},
-	{
-		dateRange: "Feb 2024 - Oct 2024",
-		title: "Autonomous Software Developer",
-		company: "WATonomous",
-		description:
-			"Trained and implemented a graph-based trajectory prediction model, leveraging the nuScenes dataset, to enhance our vehicle's autonomous navigation",
-	},
-	{
-		dateRange: "May 2024 - Aug 2024",
-		title: "Software Engineering Intern",
-		company: "Carnegie Mellon University CyLab Biometrics Center",
-		description:
-			"Built a fully autonomous robot from ground up in a team of two to deliver groceries across the CMU campus. Engineered a ROS2 software stack integrating sensor fusion (EKF), AMCL/SLAM for localization, Hybrid A* for motion planning, and MPPI for control, achieving real-time, centimeter-level accurate navigation. Integrated Jetson Orin Nano, Lidar, RTK GPS, Depth Camera, IMU, and Arduino for precise navigation. Built AI checkout system using OpenCV to prevent retail theft by classifying 250K+ Walmart products",
-	},
-	{
-		dateRange: "May 2023 - Jun 2023",
-		title: "Data Science Intern",
-		company: "MBR Technology",
-		description:
-			"Trained neural networks for image classification on public datasets like FashionMNIST and ImageNet. Trained CNN with transfer learning, achieving 96% accuracy using 7.7 million parameters",
-	},
-	{
-		dateRange: "Jun 2022 - Aug 2022",
-		title: "Software Engineer Intern",
-		company: "Palturai",
-		description:
-			"Developed an interactive knowledge graph visualization tool and a custom language for tailored filtering, aesthetic control, and enhanced data display (RDF-Viewer). Scraped SEC filings, extracting relational data to serve as test cases for RDF-Viewer",
-	},
-	{
-		dateRange: "Jun 2021 - Aug 2021",
-		title: "Software Engineer Intern",
-		company: "Palturai",
-		description:
-			"Designed Java SDK to abstract interaction with fraud detection graph database, handling 210M+ relationships",
-	},
+        {
+                dateRange: "Sep 2025 - Present",
+                title: "Software Engineer Intern",
+                company: "Super.com",
+                location: "San Francisco, California, United States · Remote",
+                employmentType: "Internship",
+                summary: "Infrastructure Team 🔧",
+                details: [
+                        "Supporting the infrastructure team with Kubernetes, AWS, and Datadog tooling to keep services reliable in a remote-first environment.",
+                ],
+                skills: ["Kubernetes", "Amazon Web Services (AWS)", "Datadog"],
+        },
+        {
+                dateRange: "Jan 2025 - May 2025",
+                title: "Fullstack Software Engineering Intern",
+                company: "Hamming AI (YC S24)",
+                location: "San Francisco, California, United States",
+                employmentType: "Internship",
+                summary: "Fullstack 🚀 YC S24",
+                details: [
+                        "Built dynamically generated IVR state machines for AI voice agent testing, directly leading to new customers.",
+                        "Investigated and fixed critical Redis concurrency issues, reducing call error rate by 85%.",
+                        "Automated frontend and backend tests using GitHub Actions and scheduled jobs to catch regressions in CI/CD.",
+                        "Enabled third-party voice agents to integrate with the Hamming platform, unlocking new customers.",
+                ],
+                skills: ["Next.js", "PostgreSQL", "Temporal", "LiveKit", "tRPC", "Datadog"],
+        },
+        {
+                dateRange: "Oct 2024 - Present",
+                title: "Member",
+                company: "Cohere Labs",
+        },
+        {
+                dateRange: "Feb 2024 - Oct 2024",
+                title: "Autonomous Software Developer",
+                company: "WATonomous",
+                location: "Waterloo, Ontario, Canada · Hybrid",
+                summary: "Machine Learning 🚙",
+                details: [
+                        "Trained and implemented a graph-based trajectory prediction model using the nuScenes dataset to enhance autonomous navigation.",
+                ],
+                skills: ["ROS2", "Docker", "PyTorch", "C++", "Python (Programming Language)"],
+        },
+        {
+                dateRange: "May 2024 - Aug 2024",
+                title: "Software Engineer Intern - CyLab Biometrics Center",
+                company: "Carnegie Mellon University",
+                location: "Pittsburgh, Pennsylvania, United States · On-site",
+                employmentType: "Internship",
+                summary: "Robotics + Computer Vision 🤖",
+                details: [
+                        "Built a fully autonomous delivery robot with a two-person team to run grocery routes across the CMU campus.",
+                        "Engineered a ROS2 stack combining sensor fusion (EKF), AMCL/SLAM localization, Hybrid A* motion planning, and MPPI control for centimeter-level navigation.",
+                        "Integrated Jetson Orin Nano, LiDAR, RTK GPS, depth camera, IMU, and Arduino hardware for precise navigation.",
+                        "Developed an AI checkout system with OpenCV to classify 250K+ Walmart products and prevent retail theft.",
+                ],
+                skills: [
+                        "ROS2",
+                        "OpenCV",
+                        "Docker",
+                        "JavaScript",
+                        "React.js",
+                        "Flask",
+                        "Express.js",
+                        "C++",
+                        "Python (Programming Language)",
+                ],
+        },
+        {
+                dateRange: "May 2023 - Jun 2023",
+                title: "Data Science Intern",
+                company: "MBR Technology",
+                summary: "Machine Learning 🧠",
+                details: [
+                        "Trained neural networks for image classification on public datasets like FashionMNIST and ImageNet.",
+                        "Applied transfer learning to a CNN with 7.7 million parameters to reach 96% accuracy.",
+                ],
+                skills: [
+                        "Pandas",
+                        "Jupyter Notebook",
+                        "NumPy",
+                        "PyTorch",
+                        "Python (Programming Language)",
+                        "Git",
+                ],
+        },
+        {
+                dateRange: "Jun 2022 - Aug 2022",
+                title: "Software Engineer Intern",
+                company: "Palturai",
+                location: "Paoli, Pennsylvania, United States · Hybrid",
+                summary: "Fullstack 🔗",
+                details: [
+                        "Developed an interactive knowledge graph visualization tool and a custom language for tailored filtering and presentation (RDF-Viewer).",
+                        "Scraped SEC filings to extract relational data that served as realistic datasets for RDF-Viewer.",
+                ],
+                skills: ["Docker", "JavaFX", "Web Scraping", "Knowledge Graphs", "Apache Jena", "Java (Programming Language)"],
+        },
+        {
+                dateRange: "Jun 2021 - Aug 2021",
+                title: "Software Engineer Intern",
+                company: "Palturai",
+                location: "Paoli, Pennsylvania",
+                summary: "Backend ⚙️",
+                details: [
+                        "Designed a Java SDK to abstract interaction with a fraud detection knowledge graph containing over 210 million relationships.",
+                ],
+                skills: ["Java (Programming Language)", "REST APIs"],
+        },
 ];


### PR DESCRIPTION
## Summary
- rework the experience timeline to use accessible buttons with a modal overlay for detailed job descriptions and skill chips
- enrich job data with summaries, bullet point details, locations, and skills to keep the cards concise while supporting the modal content

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cbf59774fc832a87e4e73a608650f8