### PR TITLE
feat: condense experience cards

### DIFF
--- a/src/components/Timeline.svelte
+++ b/src/components/Timeline.svelte
@@ -1,31 +1,47 @@
 <script>
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount, tick } from 'svelte';
 
   export let items = [
     {
-      dateRange: '2021 - Current',
-      title: 'Job 4',
+      dateRange: '2021 - Present',
+      title: 'Software Engineer Intern',
       company: 'Company 4',
+      employmentType: 'Internship',
+      location: 'Remote',
+      team: 'Infrastructure Team',
+      skills: ['Kubernetes', 'AWS', 'Datadog'],
       description: 'Customer Success Representative.',
     },
     {
       dateRange: '2019 - 2021',
-      title: 'Job 3',
+      title: 'Software Engineer',
       company: 'Company 3',
+      employmentType: 'Full-time',
+      location: 'Hybrid',
+      team: 'Platform Team',
+      skills: ['React', 'Node.js'],
       description: 'Project Management, System Administrator.',
     },
     {
       dateRange: '2018 - 2019',
-      title: 'Job 2',
+      title: 'Support Specialist',
       company: 'Company 2',
+      employmentType: 'Internship',
+      location: 'On-site',
+      team: 'Support',
+      skills: ['Customer Success'],
       description: 'Support Specialist.',
     },
     {
       dateRange: '2017 - 2018',
-      title: 'Job 1',
+      title: 'Debugging Engineer',
       company: 'Company 1',
+      employmentType: 'Part-time',
+      location: 'Remote',
+      team: 'QA',
+      skills: ['Debugging', 'QA'],
       description: 'Debugging, Code QA.',
-    }
+    },
   ];
 
   const variations = [
@@ -68,16 +84,28 @@
       floatDuration: 14,
       floatDelay: 1,
       trailSkew: 18,
-    }
+    },
   ];
 
   let cosmicItems = [];
   let visibleItems = new Set();
   let floatingItems = new Set();
+  let activeItem = null;
+  let closeButton;
+  let isBrowser = false;
+  let lastFocusedElement = null;
 
   $: cosmicItems = items.map((item, index) => {
     const variation = variations[index % variations.length];
     const side = variation.side ?? (index % 2 === 0 ? 'left' : 'right');
+    const skills = Array.isArray(item.skills) ? item.skills : [];
+    const skillPreview =
+      skills.length > 0
+        ? skills.length > 3
+          ? `${skills.slice(0, 3).join(' · ')} +${skills.length - 3} more`
+          : skills.join(' · ')
+        : null;
+    const hasSummary = Boolean(item.location || item.team || skillPreview);
 
     return {
       ...item,
@@ -87,13 +115,44 @@
       rotation: variation.rotation ?? (side === 'left' ? -12 : 12),
       scale: variation.scale ?? 0.92,
       hue: variation.hue ?? 220 + index * 24,
-      floatDuration: variation.floatDuration ?? 13 + (index % 3),
+      floatDuration: variation.floatDuration ?? (13 + (index % 3)),
       floatDelay: variation.floatDelay ?? index * 0.35,
       trailSkew: variation.trailSkew ?? (side === 'left' ? -18 : 18),
+      hasSummary,
+      skillPreview,
     };
   });
 
+  $: if (isBrowser && typeof document !== 'undefined') {
+    document.body.classList.toggle('timeline-modal-open', Boolean(activeItem));
+  }
+
+  async function openModal(item) {
+    if (typeof document !== 'undefined') {
+      const activeElement = document.activeElement;
+      if (activeElement && activeElement instanceof HTMLElement) {
+        lastFocusedElement = activeElement;
+      }
+    }
+
+    activeItem = item;
+    await tick();
+    closeButton?.focus();
+  }
+
+  function closeModal() {
+    activeItem = null;
+
+    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+      lastFocusedElement.focus();
+    }
+
+    lastFocusedElement = null;
+  }
+
   onMount(() => {
+    isBrowser = true;
+
     const nodes = Array.from(document.querySelectorAll('.asteroid'));
 
     const observer = new IntersectionObserver(
@@ -148,6 +207,27 @@
       observer.disconnect();
     };
   });
+
+  onMount(() => {
+    const handleKeydown = (event) => {
+      if (event.key === 'Escape' && activeItem) {
+        event.preventDefault();
+        closeModal();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeydown);
+    };
+  });
+
+  onDestroy(() => {
+    if (isBrowser && typeof document !== 'undefined') {
+      document.body.classList.remove('timeline-modal-open');
+    }
+  });
 </script>
 
 <div class="cosmic-stage">
@@ -161,16 +241,133 @@
       data-index={item.index}
       style={`--delay:${item.index * 140}ms; --drift:${item.drift}; --rotation:${item.rotation}deg; --scale:${item.scale}; --hue:${item.hue}; --float-duration:${item.floatDuration}s; --float-delay:${item.floatDelay}s; --trail-skew:${item.trailSkew}deg;`}
     >
-      <div class="asteroid__trail" aria-hidden="true"></div>
-      <div class="asteroid__core">
-        <span class="asteroid__date">{item.dateRange}</span>
-        <h3 class="asteroid__title">{item.title}</h3>
-        <p class="asteroid__company">{item.company}</p>
-        <p class="asteroid__description">{item.description}</p>
-      </div>
+      <button
+        class="asteroid__button"
+        type="button"
+        aria-haspopup="dialog"
+        aria-labelledby={`timeline-item-${item.index}-title timeline-item-${item.index}-company`}
+        aria-describedby={item.hasSummary ? `timeline-item-${item.index}-summary` : undefined}
+        on:click={() => openModal(item)}
+      >
+        <div class="asteroid__trail" aria-hidden="true"></div>
+        <div class="asteroid__core">
+          <div class="asteroid__header">
+            <span class="asteroid__date">{item.dateRange}</span>
+            {#if item.employmentType}
+              <span class="asteroid__badge">{item.employmentType}</span>
+            {/if}
+          </div>
+          <h3 class="asteroid__title" id={`timeline-item-${item.index}-title`}>{item.title}</h3>
+          <p class="asteroid__company" id={`timeline-item-${item.index}-company`}>
+            <span>{item.company}</span>
+            {#if item.employmentType}
+              <span class="asteroid__company-type">{item.employmentType}</span>
+            {/if}
+          </p>
+          {#if item.hasSummary}
+            <div class="asteroid__summary" id={`timeline-item-${item.index}-summary`}>
+              <p class="asteroid__summary-item">
+                <span class="asteroid__summary-icon" aria-hidden="true">📅</span>
+                <span>{item.dateRange}</span>
+              </p>
+              {#if item.location}
+                <p class="asteroid__summary-item">
+                  <span class="asteroid__summary-icon" aria-hidden="true">📍</span>
+                  <span>{item.location}</span>
+                </p>
+              {/if}
+              {#if item.team}
+                <p class="asteroid__summary-item">
+                  <span class="asteroid__summary-icon" aria-hidden="true">👥</span>
+                  <span>{item.team}</span>
+                </p>
+              {/if}
+              {#if item.skillPreview}
+                <p class="asteroid__summary-item">
+                  <span class="asteroid__summary-label">Skills</span>
+                  <span>{item.skillPreview}</span>
+                </p>
+              {/if}
+            </div>
+          {/if}
+          <div class="asteroid__cta" aria-hidden="true">
+            <span>View details</span>
+            <svg class="asteroid__cta-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M2 6h6.2L5.4 3.2 6.8 1.8 11 6l-4.2 4.2-1.4-1.4L8.2 6H2z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
+        </div>
+      </button>
     </article>
   {/each}
 </div>
+
+{#if activeItem}
+  <div class="timeline-modal-layer" role="presentation">
+    <button
+      class="timeline-modal-backdrop"
+      type="button"
+      aria-label="Close experience details"
+      tabindex="-1"
+      on:click={closeModal}
+    ></button>
+    <div
+      class="timeline-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`timeline-modal-${activeItem.index}-title`}
+    >
+      <button
+        class="timeline-modal__close"
+        type="button"
+        aria-label="Close experience details"
+        on:click={closeModal}
+        bind:this={closeButton}
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+      <span class="timeline-modal__date">{activeItem.dateRange}</span>
+      <h3 class="timeline-modal__title" id={`timeline-modal-${activeItem.index}-title`}>
+        {activeItem.title}
+      </h3>
+      <p class="timeline-modal__company">{activeItem.company}</p>
+      <div class="timeline-modal__meta">
+        {#if activeItem.employmentType}
+          <span>{activeItem.employmentType}</span>
+        {/if}
+        {#if activeItem.location}
+          <span>{activeItem.location}</span>
+        {/if}
+      </div>
+      {#if activeItem.team}
+        <p class="timeline-modal__team">{activeItem.team}</p>
+      {/if}
+      {#if activeItem.skills?.length}
+        <div class="timeline-modal__skills" aria-label="Skills">
+          {#each activeItem.skills as skill}
+            <span>{skill}</span>
+          {/each}
+        </div>
+      {/if}
+      {#if activeItem.details?.length}
+        <ul class="timeline-modal__details">
+          {#each activeItem.details as detail}
+            <li>{detail}</li>
+          {/each}
+        </ul>
+      {:else if activeItem.description}
+        <p class="timeline-modal__description">{activeItem.description}</p>
+      {:else}
+        <p class="timeline-modal__description timeline-modal__description--muted">
+          More details coming soon.
+        </p>
+      {/if}
+    </div>
+  </div>
+{/if}
 
 <style>
   .cosmic-stage {
@@ -293,6 +490,8 @@
     transition-delay: var(--delay, 0ms);
     filter: blur(10px);
     will-change: transform, opacity;
+    cursor: pointer;
+    outline: none;
   }
 
   .asteroid[data-side='left'] {
@@ -303,6 +502,22 @@
   .asteroid[data-side='right'] {
     margin-left: auto;
     padding-left: clamp(0.75rem, 4vw, 2.5rem);
+  }
+
+  .asteroid__button {
+    display: block;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    border: none;
+    background: none;
+    text-align: left;
+    color: inherit;
+    cursor: inherit;
+  }
+
+  .asteroid__button:focus {
+    outline: none;
   }
 
   .asteroid::before {
@@ -359,6 +574,10 @@
       inset 0 0 0 1px rgba(255, 255, 255, 0.06),
       0 18px 40px rgba(10, 15, 37, 0.55);
     backdrop-filter: blur(12px);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    transition: border-color 0.35s ease, box-shadow 0.35s ease;
   }
 
   .asteroid__core::before {
@@ -409,6 +628,14 @@
     transform-origin: 0% 50%;
   }
 
+  .asteroid__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.35rem;
+  }
+
   .asteroid__date {
     display: inline-flex;
     align-items: center;
@@ -417,7 +644,6 @@
     text-transform: uppercase;
     letter-spacing: 0.18em;
     color: rgba(210, 236, 255, 0.8);
-    margin-bottom: 0.9rem;
   }
 
   .asteroid__date::before {
@@ -429,27 +655,119 @@
     box-shadow: 0 0 16px hsla(var(--hue, 210), 90%, 72%, 0.8);
   }
 
+  .asteroid__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(82, 126, 214, 0.35), rgba(126, 214, 255, 0.2));
+    border: 1px solid rgba(141, 197, 255, 0.3);
+    color: rgba(224, 241, 255, 0.85);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    white-space: nowrap;
+  }
+
   .asteroid__title {
     font-size: clamp(1.15rem, 2.4vw, 1.5rem);
     font-weight: 700;
-    margin: 0 0 0.35rem;
+    margin: 0;
     color: hsl(var(--hue, 210), 88%, 70%);
     text-shadow: 0 0 20px hsla(var(--hue, 210), 92%, 70%, 0.6);
   }
 
   .asteroid__company {
-    margin: 0 0 0.75rem;
+    margin: 0.15rem 0 0;
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     font-weight: 600;
-    font-style: italic;
     letter-spacing: 0.02em;
-    color: rgba(188, 230, 255, 0.85);
+    color: rgba(188, 230, 255, 0.9);
   }
 
-  .asteroid__description {
-    margin: 0;
-    color: rgba(221, 235, 255, 0.85);
-    line-height: 1.55;
-    font-size: 0.98rem;
+  .asteroid__company-type {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.18rem 0.65rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(82, 126, 214, 0.32), rgba(126, 214, 255, 0.12));
+    border: 1px solid rgba(126, 214, 255, 0.3);
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(208, 238, 255, 0.85);
+    white-space: nowrap;
+  }
+
+  .asteroid__summary {
+    margin-top: 0.9rem;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .asteroid__summary-item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: rgba(210, 236, 255, 0.78);
+    font-size: 0.84rem;
+    line-height: 1.45;
+  }
+
+  .asteroid__summary-item span:last-child {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .asteroid__summary-icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    background: rgba(72, 108, 168, 0.42);
+    color: rgba(208, 238, 255, 0.96);
+    font-size: 0.78rem;
+    box-shadow: 0 0 10px rgba(98, 170, 255, 0.25);
+  }
+
+  .asteroid__summary-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: rgba(208, 236, 255, 0.85);
+    flex-shrink: 0;
+  }
+
+  .asteroid__cta {
+    margin-top: 1.15rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.42rem 0.85rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(126, 214, 255, 0.14), rgba(126, 214, 255, 0.05));
+    border: 1px solid rgba(126, 214, 255, 0.28);
+    font-size: 0.75rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: rgba(167, 218, 255, 0.72);
+    transition: background 0.35s ease, border-color 0.35s ease, color 0.35s ease, transform 0.35s ease;
+  }
+
+  .asteroid__cta-icon {
+    transition: transform 0.35s ease;
   }
 
   .asteroid.is-visible {
@@ -480,6 +798,27 @@
     animation: trail-flicker 4s ease-in-out infinite;
   }
 
+  .asteroid.is-visible:hover .asteroid__core,
+  .asteroid__button:focus-visible .asteroid__core {
+    border-color: rgba(141, 197, 255, 0.45);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.1),
+      0 22px 44px rgba(15, 22, 45, 0.65);
+  }
+
+  .asteroid.is-visible:hover .asteroid__cta,
+  .asteroid__button:focus-visible .asteroid__cta {
+    background: linear-gradient(135deg, rgba(126, 214, 255, 0.24), rgba(126, 214, 255, 0.1));
+    border-color: rgba(126, 214, 255, 0.45);
+    color: rgba(208, 238, 255, 0.95);
+    transform: translateY(-1px);
+  }
+
+  .asteroid.is-visible:hover .asteroid__cta-icon,
+  .asteroid__button:focus-visible .asteroid__cta-icon {
+    transform: translateX(4px);
+  }
+
   @keyframes float {
     0% {
       transform: translate3d(0, 0, 0) scale(1) rotate(0);
@@ -503,6 +842,198 @@
     50% {
       opacity: 0.2;
     }
+  }
+
+  .timeline-modal-layer {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: clamp(1.5rem, 6vw, 3rem);
+    z-index: 99;
+  }
+
+  .timeline-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    border: none;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(circle at 20% 20%, rgba(59, 84, 136, 0.55), transparent 70%), rgba(6, 10, 22, 0.78);
+    backdrop-filter: blur(14px);
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .timeline-modal-backdrop:focus-visible,
+  .timeline-modal-backdrop:hover {
+    outline: 2px solid rgba(126, 214, 255, 0.35);
+  }
+
+  .timeline-modal {
+    position: relative;
+    z-index: 2;
+    max-width: 560px;
+    width: min(100%, 520px);
+    max-height: min(85vh, 720px);
+    overflow: auto;
+    padding: clamp(1.75rem, 4vw, 2.5rem);
+    border-radius: 24px;
+    background: linear-gradient(160deg, rgba(18, 29, 52, 0.95), rgba(11, 16, 30, 0.85));
+    border: 1px solid rgba(141, 197, 255, 0.2);
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+      0 32px 80px rgba(5, 9, 24, 0.65);
+    color: #e8f2ff;
+  }
+
+  .timeline-modal__close {
+    position: absolute;
+    top: 1.1rem;
+    right: 1.1rem;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 999px;
+    background: rgba(17, 28, 46, 0.85);
+    border: 1px solid rgba(141, 197, 255, 0.35);
+    color: rgba(231, 244, 255, 0.95);
+    font-size: 1.45rem;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .timeline-modal__close:hover,
+  .timeline-modal__close:focus-visible {
+    background: rgba(46, 86, 146, 0.85);
+    box-shadow: 0 0 0 3px rgba(126, 214, 255, 0.25);
+  }
+
+  .timeline-modal__date {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(208, 230, 255, 0.8);
+    margin-bottom: 1rem;
+  }
+
+  .timeline-modal__date::before {
+    content: '';
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(110, 193, 255, 0.8), rgba(255, 255, 255, 0.75));
+    box-shadow: 0 0 22px rgba(126, 214, 255, 0.8);
+  }
+
+  .timeline-modal__title {
+    margin: 0 0 0.35rem;
+    font-size: clamp(1.4rem, 3vw, 1.8rem);
+    font-weight: 700;
+    color: #f0f6ff;
+  }
+
+  .timeline-modal__company {
+    margin: 0 0 1.1rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: rgba(198, 226, 255, 0.9);
+  }
+
+  .timeline-modal__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .timeline-modal__meta span {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.3rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(67, 102, 168, 0.35);
+    border: 1px solid rgba(126, 214, 255, 0.25);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(219, 240, 255, 0.9);
+  }
+
+  .timeline-modal__team {
+    margin: 0 0 0.75rem;
+    font-weight: 600;
+    color: rgba(233, 243, 255, 0.95);
+    letter-spacing: 0.05em;
+  }
+
+  .timeline-modal__skills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.3rem;
+  }
+
+  .timeline-modal__skills span {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.25rem 0.65rem;
+    border-radius: 0.75rem;
+    background: rgba(44, 74, 126, 0.6);
+    border: 1px solid rgba(126, 214, 255, 0.2);
+    font-size: 0.78rem;
+    color: rgba(221, 238, 255, 0.95);
+  }
+
+  .timeline-modal__details {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.85rem;
+    color: rgba(224, 238, 255, 0.92);
+    font-size: 0.98rem;
+    line-height: 1.65;
+  }
+
+  .timeline-modal__details li {
+    position: relative;
+    padding-left: 1.4rem;
+  }
+
+  .timeline-modal__details li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.65rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(126, 214, 255, 0.9), rgba(255, 255, 255, 0.85));
+    box-shadow: 0 0 12px rgba(126, 214, 255, 0.65);
+  }
+
+  .timeline-modal__description {
+    margin: 0;
+    color: rgba(224, 238, 255, 0.9);
+    line-height: 1.65;
+    font-size: 0.98rem;
+  }
+
+  .timeline-modal__description--muted {
+    color: rgba(189, 210, 232, 0.7);
+    font-style: italic;
+  }
+
+  :global(body.timeline-modal-open) {
+    overflow: hidden;
   }
 
   @media (max-width: 900px) {
@@ -535,6 +1066,10 @@
     .asteroid__trail {
       display: none;
     }
+
+    .timeline-modal {
+      width: min(100%, 480px);
+    }
   }
 
   @media (max-width: 560px) {
@@ -560,8 +1095,22 @@
       font-size: clamp(1.1rem, 4vw, 1.35rem);
     }
 
-    .asteroid__description {
-      font-size: 0.95rem;
+    .asteroid__skills {
+      font-size: 0.78rem;
+    }
+
+    .asteroid__cta {
+      margin-top: 0.9rem;
+    }
+
+    .timeline-modal {
+      padding: 1.75rem 1.25rem 2rem;
+      max-height: 80vh;
+    }
+
+    .timeline-modal__close {
+      top: 0.9rem;
+      right: 0.9rem;
     }
   }
 
@@ -579,6 +1128,10 @@
 
     .asteroid.is-floating .asteroid__trail::after {
       animation: none;
+    }
+
+    .timeline-modal-backdrop {
+      backdrop-filter: none;
     }
   }
 </style>

--- a/src/data/jobs.ts
+++ b/src/data/jobs.ts
@@ -1,62 +1,119 @@
 export interface Job {
-	dateRange: string;
-	title: string;
-	company: string;
-	description: string;
+  dateRange: string;
+  title: string;
+  company: string;
+  description?: string;
+  details?: string[];
+  employmentType?: string;
+  location?: string;
+  team?: string;
+  skills?: string[];
 }
 
 export const jobs: Job[] = [
-	{
-		dateRange: "Sep 2025 - Dec 2025",
-		title: "Software Engineering Intern, Infrastructure",
-		company: "Super.com",
-		description: "",
-	},
-	{
-		dateRange: "Jan 2025 - May 2025",
-		title: "Fullstack Software Engineering Intern",
-		company: "Hamming AI (YC S24)",
-		description: "Built dynamically generated IVR state machines for AI voice agent testing, directly leading to new customers. Investigated and fixed critical Redis concurrency issues, reducing call error rate by 85%. Automated frontend and backend tests using GitHub Actions and scheduled jobs to catch regressions in CI/CD. Enabled third-party voice agents to integrate with the Hamming platform, unlocking new customers.",
-	},
-	{
-		dateRange: "Oct 2024 - Current",
-		title: "Member",
-		company: "Cohere For AI",
-		description: "",
-	},
-	{
-		dateRange: "Feb 2024 - Oct 2024",
-		title: "Autonomous Software Developer",
-		company: "WATonomous",
-		description:
-			"Trained and implemented a graph-based trajectory prediction model, leveraging the nuScenes dataset, to enhance our vehicle's autonomous navigation",
-	},
-	{
-		dateRange: "May 2024 - Aug 2024",
-		title: "Software Engineering Intern",
-		company: "Carnegie Mellon University CyLab Biometrics Center",
-		description:
-			"Built a fully autonomous robot from ground up in a team of two to deliver groceries across the CMU campus. Engineered a ROS2 software stack integrating sensor fusion (EKF), AMCL/SLAM for localization, Hybrid A* for motion planning, and MPPI for control, achieving real-time, centimeter-level accurate navigation. Integrated Jetson Orin Nano, Lidar, RTK GPS, Depth Camera, IMU, and Arduino for precise navigation. Built AI checkout system using OpenCV to prevent retail theft by classifying 250K+ Walmart products",
-	},
-	{
-		dateRange: "May 2023 - Jun 2023",
-		title: "Data Science Intern",
-		company: "MBR Technology",
-		description:
-			"Trained neural networks for image classification on public datasets like FashionMNIST and ImageNet. Trained CNN with transfer learning, achieving 96% accuracy using 7.7 million parameters",
-	},
-	{
-		dateRange: "Jun 2022 - Aug 2022",
-		title: "Software Engineer Intern",
-		company: "Palturai",
-		description:
-			"Developed an interactive knowledge graph visualization tool and a custom language for tailored filtering, aesthetic control, and enhanced data display (RDF-Viewer). Scraped SEC filings, extracting relational data to serve as test cases for RDF-Viewer",
-	},
-	{
-		dateRange: "Jun 2021 - Aug 2021",
-		title: "Software Engineer Intern",
-		company: "Palturai",
-		description:
-			"Designed Java SDK to abstract interaction with fraud detection graph database, handling 210M+ relationships",
-	},
+  {
+    dateRange: "Sep 2025 - Present",
+    title: "Software Engineer Intern",
+    company: "Super.com",
+    employmentType: "Internship",
+    location: "San Francisco, California, United States · Remote",
+    team: "Infrastructure Team 🔧",
+    skills: ["Kubernetes", "Amazon Web Services (AWS)", "Datadog"],
+  },
+  {
+    dateRange: "Dec 2024 - Apr 2025",
+    title: "Software Engineer Intern",
+    company: "Hamming AI (YC S24)",
+    employmentType: "Internship",
+    location: "San Francisco, California, United States",
+    team: "Fullstack 🚀 YC S24",
+    skills: ["Next.js", "PostgreSQL", "Temporal", "LiveKit", "tRPC", "Datadog"],
+    details: [
+      "Built dynamically generated IVR state machines for AI voice agent testing, directly leading to new customers.",
+      "Investigated and fixed critical Redis concurrency issues, reducing call error rate by 85%.",
+      "Automated frontend and backend tests using GitHub Actions and scheduled jobs to catch regressions in CI/CD.",
+      "Enabled third-party voice agents to integrate with the Hamming platform, unlocking new customers.",
+    ],
+  },
+  {
+    dateRange: "Oct 2024 - Present",
+    title: "Member - Cohere Labs",
+    company: "Cohere",
+    employmentType: "Fellowship",
+  },
+  {
+    dateRange: "Feb 2024 - Oct 2024",
+    title: "Autonomous Software Developer",
+    company: "WATonomous",
+    employmentType: "Part-time",
+    location: "Waterloo, Ontario, Canada · Hybrid",
+    team: "Machine Learning 🚙",
+    skills: ["ROS2", "Docker", "PyTorch", "C++", "Python"],
+    details: [
+      "Trained a graph-based trajectory prediction model leveraging the nuScenes dataset.",
+      "Implemented the predictor in the autonomy stack to enhance the vehicle's autonomous navigation.",
+    ],
+  },
+  {
+    dateRange: "May 2024 - Aug 2024",
+    title: "Software Engineer Intern - CyLab Biometrics Center",
+    company: "Carnegie Mellon University",
+    employmentType: "Internship",
+    location: "Pittsburgh, Pennsylvania, United States · On-site",
+    team: "Robotics + Computer Vision 🤖",
+    skills: [
+      "ROS2",
+      "OpenCV",
+      "Docker",
+      "JavaScript",
+      "React.js",
+      "Flask",
+      "Express.js",
+      "C++",
+      "Python",
+    ],
+    details: [
+      "Built a fully autonomous robot from the ground up with a two-person team to deliver groceries across the CMU campus.",
+      "Engineered a ROS2 software stack integrating sensor fusion (EKF), AMCL/SLAM for localization, Hybrid A* for motion planning, and MPPI for control to achieve real-time, centimeter-level navigation.",
+      "Integrated Jetson Orin Nano, LiDAR, RTK GPS, depth camera, IMU, and Arduino hardware for precise navigation.",
+      "Built an AI checkout system using OpenCV to classify 250K+ Walmart products and prevent retail theft.",
+    ],
+  },
+  {
+    dateRange: "May 2023 - Jun 2023",
+    title: "Data Science Intern",
+    company: "MBR Technology",
+    employmentType: "Internship",
+    team: "Machine Learning 🧠",
+    skills: ["Pandas", "Jupyter Notebook", "NumPy", "PyTorch", "Python", "Git"],
+    details: [
+      "Trained neural networks for image classification on public datasets like FashionMNIST and ImageNet.",
+      "Applied transfer learning to reach 96% accuracy with a 7.7 million parameter CNN.",
+    ],
+  },
+  {
+    dateRange: "Jun 2022 - Aug 2022",
+    title: "Software Engineer Intern",
+    company: "Palturai",
+    employmentType: "Internship",
+    location: "Paoli, Pennsylvania, United States · Hybrid",
+    team: "Fullstack 🔗",
+    skills: ["Docker", "JavaFX", "Web Scraping", "Knowledge Graphs", "Apache Jena", "Java"],
+    details: [
+      "Developed an interactive knowledge graph visualization tool and custom language for tailored filtering, aesthetic control, and enhanced data display (RDF-Viewer).",
+      "Scraped SEC filings and extracted relational data to serve as test cases for RDF-Viewer.",
+    ],
+  },
+  {
+    dateRange: "Jun 2021 - Aug 2021",
+    title: "Software Engineer Intern",
+    company: "Palturai",
+    employmentType: "Internship",
+    location: "Paoli, Pennsylvania, United States",
+    team: "Backend ⚙️",
+    skills: ["Java", "REST APIs"],
+    details: [
+      "Designed a Java SDK to abstract interaction with a fraud detection graph database handling 210M+ relationships.",
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- compact the experience timeline cards so they show a concise summary row with icons, employment badges, and a clearer CTA while keeping them as accessible dialog triggers
- surface bullet-pointed highlights inside the experience modal and adjust styling to support the new layout
- add structured `details` arrays to each job entry so the modal can display focused accomplishments

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cbf59774fc832a87e4e73a608650f8