### PR TITLE
feat(experience): compact timeline with modal details

### DIFF
--- a/src/data/jobs.ts
+++ b/src/data/jobs.ts
@@ -1,62 +1,127 @@
 export interface Job {
-	dateRange: string;
-	title: string;
-	company: string;
-	description: string;
+  dateRange: string;
+  tenure?: string;
+  title: string;
+  company: string;
+  summary?: string;
+  location?: string;
+  employmentType?: string;
+  skills?: string[];
+  highlights?: string[];
+  description?: string;
 }
 
 export const jobs: Job[] = [
-	{
-		dateRange: "Sep 2025 - Dec 2025",
-		title: "Software Engineering Intern, Infrastructure",
-		company: "Super.com",
-		description: "",
-	},
-	{
-		dateRange: "Jan 2025 - May 2025",
-		title: "Fullstack Software Engineering Intern",
-		company: "Hamming AI (YC S24)",
-		description: "Built dynamically generated IVR state machines for AI voice agent testing, directly leading to new customers. Investigated and fixed critical Redis concurrency issues, reducing call error rate by 85%. Automated frontend and backend tests using GitHub Actions and scheduled jobs to catch regressions in CI/CD. Enabled third-party voice agents to integrate with the Hamming platform, unlocking new customers.",
-	},
-	{
-		dateRange: "Oct 2024 - Current",
-		title: "Member",
-		company: "Cohere For AI",
-		description: "",
-	},
-	{
-		dateRange: "Feb 2024 - Oct 2024",
-		title: "Autonomous Software Developer",
-		company: "WATonomous",
-		description:
-			"Trained and implemented a graph-based trajectory prediction model, leveraging the nuScenes dataset, to enhance our vehicle's autonomous navigation",
-	},
-	{
-		dateRange: "May 2024 - Aug 2024",
-		title: "Software Engineering Intern",
-		company: "Carnegie Mellon University CyLab Biometrics Center",
-		description:
-			"Built a fully autonomous robot from ground up in a team of two to deliver groceries across the CMU campus. Engineered a ROS2 software stack integrating sensor fusion (EKF), AMCL/SLAM for localization, Hybrid A* for motion planning, and MPPI for control, achieving real-time, centimeter-level accurate navigation. Integrated Jetson Orin Nano, Lidar, RTK GPS, Depth Camera, IMU, and Arduino for precise navigation. Built AI checkout system using OpenCV to prevent retail theft by classifying 250K+ Walmart products",
-	},
-	{
-		dateRange: "May 2023 - Jun 2023",
-		title: "Data Science Intern",
-		company: "MBR Technology",
-		description:
-			"Trained neural networks for image classification on public datasets like FashionMNIST and ImageNet. Trained CNN with transfer learning, achieving 96% accuracy using 7.7 million parameters",
-	},
-	{
-		dateRange: "Jun 2022 - Aug 2022",
-		title: "Software Engineer Intern",
-		company: "Palturai",
-		description:
-			"Developed an interactive knowledge graph visualization tool and a custom language for tailored filtering, aesthetic control, and enhanced data display (RDF-Viewer). Scraped SEC filings, extracting relational data to serve as test cases for RDF-Viewer",
-	},
-	{
-		dateRange: "Jun 2021 - Aug 2021",
-		title: "Software Engineer Intern",
-		company: "Palturai",
-		description:
-			"Designed Java SDK to abstract interaction with fraud detection graph database, handling 210M+ relationships",
-	},
+  {
+    dateRange: "Sep 2025 - Present",
+    tenure: "Sep 2025 to Present · 1 mo",
+    title: "Software Engineer Intern",
+    company: "Super.com",
+    summary: "Infrastructure Team 🔧",
+    employmentType: "Internship",
+    location: "San Francisco, California, United States · Remote",
+    skills: ["Kubernetes", "Amazon Web Services (AWS)", "Datadog"],
+  },
+  {
+    dateRange: "Dec 2024 - Apr 2025",
+    tenure: "Dec 2024 to Apr 2025 · 5 mos",
+    title: "Software Engineer Intern",
+    company: "Hamming AI (YC S24)",
+    summary: "Fullstack 🚀 YC S24",
+    employmentType: "Internship",
+    location: "San Francisco, California, United States",
+    skills: ["Next.js", "PostgreSQL", "Temporal", "LiveKit", "tRPC", "Datadog"],
+    highlights: [
+      "Built dynamically generated IVR state machines for AI voice agent testing, unlocking new customer deployments.",
+      "Investigated and resolved critical Redis concurrency issues, reducing call error rates by 85%.",
+      "Automated frontend and backend test suites with GitHub Actions and scheduled jobs to catch regressions early.",
+      "Enabled third-party voice agents to integrate with the Hamming platform, opening new revenue channels.",
+    ],
+  },
+  {
+    dateRange: "Oct 2024 - Present",
+    tenure: "Oct 2024 to Present · 1 yr",
+    title: "Member · Cohere Labs",
+    company: "Cohere",
+    summary: "Cohere Labs",
+  },
+  {
+    dateRange: "Feb 2024 - Oct 2024",
+    tenure: "Feb 2024 to Oct 2024 · 9 mos",
+    title: "Autonomous Software Developer",
+    company: "WATonomous",
+    summary: "Machine Learning 🚙",
+    employmentType: "Part-time",
+    location: "Waterloo, Ontario, Canada · Hybrid",
+    skills: ["ROS2", "Docker", "PyTorch", "C++", "Python (Programming Language)"],
+    highlights: [
+      "Trained and deployed a graph-based trajectory prediction model with the nuScenes dataset to improve autonomous navigation.",
+    ],
+  },
+  {
+    dateRange: "May 2024 - Aug 2024",
+    tenure: "May 2024 to Aug 2024 · 4 mos",
+    title: "Software Engineer Intern · CyLab Biometrics Center",
+    company: "Carnegie Mellon University",
+    summary: "Robotics + Computer Vision 🤖",
+    employmentType: "Internship",
+    location: "Pittsburgh, Pennsylvania, United States · On-site",
+    skills: [
+      "ROS2",
+      "OpenCV",
+      "Docker",
+      "JavaScript",
+      "React.js",
+      "Flask",
+      "Express.js",
+      "C++",
+      "Python (Programming Language)",
+    ],
+    highlights: [
+      "Built a fully autonomous robot in a two-person team to deliver groceries across campus with centimeter-level accuracy.",
+      "Engineered a ROS2 stack integrating sensor fusion (EKF), AMCL/SLAM localization, Hybrid A* planning, and MPPI control.",
+      "Integrated Jetson Orin Nano, LiDAR, RTK GPS, depth camera, IMU, and Arduino hardware for precise navigation.",
+      "Developed an AI checkout system with OpenCV to classify more than 250K Walmart products and deter retail theft.",
+    ],
+  },
+  {
+    dateRange: "May 2023 - Jun 2023",
+    tenure: "May 2023 to Jun 2023 · 2 mos",
+    title: "Data Science Intern",
+    company: "MBR Technology",
+    summary: "Machine Learning 🧠",
+    employmentType: "Internship",
+    skills: ["Pandas", "Jupyter Notebook", "NumPy", "PyTorch", "Python (Programming Language)", "Git"],
+    highlights: [
+      "Trained neural networks for image classification on FashionMNIST and ImageNet datasets.",
+      "Fine-tuned convolutional models with transfer learning, reaching 96% accuracy using 7.7 million parameters.",
+    ],
+  },
+  {
+    dateRange: "Jun 2022 - Aug 2022",
+    tenure: "Jun 2022 to Aug 2022 · 3 mos",
+    title: "Software Engineer Intern",
+    company: "Palturai",
+    summary: "Fullstack 🔗",
+    employmentType: "Part-time",
+    location: "Paoli, Pennsylvania, United States · Hybrid",
+    skills: ["Docker", "JavaFX", "Web Scraping", "Knowledge Graphs", "Apache Jena", "Java (Programming Language)"],
+    highlights: [
+      "Developed an interactive knowledge graph visualization tool with a custom language for filtering and presentation.",
+      "Scraped SEC filings and extracted relational data to build comprehensive test scenarios for the RDF-Viewer.",
+    ],
+  },
+  {
+    dateRange: "Jun 2021 - Aug 2021",
+    tenure: "Jun 2021 to Aug 2021 · 3 mos",
+    title: "Software Engineer Intern",
+    company: "Palturai",
+    summary: "Backend ⚙️",
+    employmentType: "Internship",
+    location: "Paoli, Pennsylvania, United States",
+    skills: ["Java (Programming Language)", "REST APIs"],
+    highlights: [
+      "Designed a Java SDK to abstract fraud-detection graph database interactions across 210M+ relationships.",
+    ],
+  },
 ];


### PR DESCRIPTION
## Summary
- render experience timeline cards as condensed LinkedIn-style buttons that open a modal with full role details, scroll locking, and focus/ESC handling
- add modal/backdrop styling, skill pills, and an underlay button so clicking the backdrop closes the dialog without a11y warnings
- update the job dataset with tenure strings, short summaries, and skill/highlight lists to power the new card layout

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cbf59774fc832a87e4e73a608650f8