### PR TITLE
Fix pnpm workflow version mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -54,4 +52,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        


### PR DESCRIPTION
## Summary

- Remove the explicit `version: 9` input from `pnpm/action-setup@v4`.
- Use the exact pnpm version already pinned by `package.json` via `packageManager`.

## Root cause

The deployment workflow declared pnpm `9` in the action configuration while `package.json` declared `pnpm@9.15.9` with an integrity hash. `pnpm/action-setup@v4` rejects multiple pnpm version declarations.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- `ASTRO_TELEMETRY_DISABLED=1 ./node_modules/.bin/astro build` passed; the build retains the existing `lottie-web` direct-`eval` warning.

This follow-up should allow the GitHub Pages deployment to proceed past the pnpm setup step.