### PR TITLE
Move site hosting to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Redirect GitHub Pages
 
 on:
   push:
@@ -10,45 +10,25 @@ permissions:
   pages: write
   id-token: write
 
-# Prevent overlapping deployments
 concurrency:
-  group: "pages"
+  group: "github-pages-redirect"
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.12.0
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Astro site
-        run: pnpm run build
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./dist
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload redirect artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./github-pages-redirect
+
+      - name: Deploy redirect to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://dygitz.github.io',
+  site: 'https://dominikritz.com',
   integrations: [svelte()],
   vite: {
     plugins: [tailwindcss()]

--- a/github-pages-redirect/index.html
+++ b/github-pages-redirect/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0;url=https://dominikritz.com/" />
+    <link rel="canonical" href="https://dominikritz.com/" />
+    <title>Redirecting to Dominik Ritz</title>
+    <script>
+      window.location.replace('https://dominikritz.com/');
+    </script>
+  </head>
+  <body>
+    <p>
+      This site has moved to
+      <a href="https://dominikritz.com/">dominikritz.com</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## What changed

- update Astro's canonical site URL to `https://dominikritz.com`
- deploy a redirect-only artifact from GitHub Pages so `dygitz.github.io` forwards visitors to the new domain
- remove the GitHub Pages build/dependency steps; the site build is handled by the Cloudflare Pages Git integration

The Cloudflare Pages project `dominikritz` is configured for `Dygitz/dygitz.github.io` on `main`, with `dominikritz.com` attached separately.

## Validation

- workflow YAML parsed successfully
- redirect target verified
- `astro build` passed
- `git diff --check` passed

Please keep this PR as a draft until the Cloudflare domain and deployment are confirmed.