### PR TITLE
Add astronaut favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,9 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <title>Astronaut helmet</title>
+  <defs>
+    <linearGradient id="bg" x1="12" y1="8" x2="116" y2="120" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#312e81" />
+      <stop offset="1" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="visor" x1="42" y1="42" x2="86" y2="82" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#67e8f9" />
+      <stop offset="1" stop-color="#8b5cf6" />
+    </linearGradient>
+  </defs>
+  <circle cx="64" cy="64" r="62" fill="url(#bg)" />
+  <path fill="#f8fafc" d="M64 22c-21 0-38 16-38 37v18c0 7 5 13 12 15l7 2v8c0 3 2 5 5 5h28c3 0 5-2 5-5v-8l7-2c7-2 12-8 12-15V59c0-21-17-37-38-37Zm-24 37c0-13 11-24 24-24s24 11 24 24v18H40V59Zm42 35H46v-7h36v7Z" />
+  <path fill="url(#visor)" d="M43 60c0-11 9-20 21-20s21 9 21 20v10H43V60Z" />
+  <path fill="#e0f2fe" d="M48 58c2-7 8-12 16-14-5 5-8 11-9 18h-7v-4Z" opacity=".8" />
+  <circle cx="34" cy="35" r="2" fill="#f8fafc" opacity=".8" />
+  <circle cx="97" cy="29" r="1.5" fill="#f8fafc" opacity=".8" />
+  <circle cx="101" cy="96" r="2" fill="#f8fafc" opacity=".7" />
 </svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,7 @@ import { jobs } from "../data/jobs";
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<title>Dominik Ritz</title>
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## What changed

- replace the generic favicon asset with a compact astronaut helmet SVG
- explicitly link `/favicon.svg` from the Astro document head

## Why

The site was not declaring its favicon, so browsers could fall back to a Cloudflare icon. This gives the personal site its own astronaut-themed tab icon.

## Validation

- focused favicon source checks passed
- `git diff --check` passed
- `ASTRO_TELEMETRY_DISABLED=1 pnpm run build` passed
- generated `dist/index.html` references `/favicon.svg`
- generated `dist/favicon.svg` is present

The PR is intentionally limited to the favicon implementation.