### PR TITLE
feat: add orbital projects gallery

### DIFF
--- a/docs/superpowers/specs/2026-07-30-orbital-projects-gallery-design.md
+++ b/docs/superpowers/specs/2026-07-30-orbital-projects-gallery-design.md
@@ -1,0 +1,140 @@
+# Orbital Projects Gallery Design
+
+Date: 2026-07-30
+
+## Summary
+
+Add an immersive projects section to the portfolio using an orbital gallery. Five featured projects appear as planets around a central focus point. Selecting a project pulls it into an Event Horizon-style mission card while the other projects recede. The card stays concise and sends visitors to the project’s live demo.
+
+The section will extend the existing astronaut, animated starfield, gradient, and black-hole cursor language without adding another rendering canvas or embedding external demos.
+
+## Goals
+
+- Make projects the most visually memorable section after the hero.
+- Use the existing space theme as interaction, not only decoration.
+- Surface live demo links with a clear primary action.
+- Keep project information scannable: title, category, impact, technologies, and links.
+- Work on desktop, mobile, keyboard navigation, touch input, and reduced-motion settings.
+- Keep the first version focused and maintainable within the existing Astro + Svelte structure.
+
+## Non-goals
+
+- Embedded live-demo iframes.
+- Full case-study pages or long project descriptions inside the card.
+- Project filters, search, CMS integration, analytics, or remote project data.
+- A second PixiJS canvas or a new animation/rendering dependency.
+
+## Placement and visual language
+
+Place the section after About and before Experience in `src/pages/index.astro`. Use a clear `Projects` section heading with mission language in the interface, such as `Mission 01 / 05` and `Launch Demo`.
+
+The visual treatment is Event Horizon:
+
+- Near-black card surfaces that visually connect to the black-hole cursor.
+- Violet singularity glow as the primary selected-state accent.
+- Cyan and pink highlights for telemetry, links, and project-specific accents.
+- Subtle radial gradients, thin orbital lines, and a restrained glass/frost edge highlight.
+- Strong contrast between the dark card and light text; decorative glows must not carry meaning alone.
+
+The orbit should feel dimensional without becoming a competing hero animation. The focused card is the visual anchor; orbiting planets remain recognizable but secondary.
+
+## User experience
+
+### Default state
+
+When the section enters the viewport, the orbit is visible with five project nodes and one active project in the center card. The orbit may rotate slowly while idle, but it must pause while the user hovers, focuses, drags, or selects.
+
+### Selecting a project
+
+Users can select a project by clicking its planet, scrolling through the section, using left/right arrow keys, or swiping on touch devices. Selection advances one project at a time and animates the chosen planet toward the focus position. The focused project card expands while non-selected planets dim and move farther from the center.
+
+The existing black-hole cursor may apply a subtle gravitational pull to nearby planets on desktop. This is ambient feedback only; selecting a project must never require a pointer or cursor effect.
+
+### Focused mission card
+
+The card contains:
+
+- Project title.
+- Category or role label.
+- One concise impact statement.
+- Three or four technology tags.
+- Primary `Launch Demo` link.
+- Optional secondary GitHub link.
+- Mission position indicator, such as `Mission 03 / 05`.
+
+The live demo opens in a new tab using `rel="noopener noreferrer"`. The portfolio page does not depend on the external demo loading successfully.
+
+### Responsive behavior
+
+On desktop, planets follow elliptical orbital paths around the focused card. On mobile, the same state model becomes a swipeable carousel: the active card occupies most of the viewport, with smaller orbit markers or neighboring project glimpses preserving the planetary metaphor.
+
+### Motion and reduced motion
+
+Use CSS/Svelte transitions for position, scale, opacity, and glow. Avoid continuous motion during active interaction. With `prefers-reduced-motion: reduce`, keep the orbit static and replace movement with short fades and state changes.
+
+## Component and data design
+
+### Data
+
+Create `src/data/projects.ts` with a typed project model:
+
+```ts
+export interface Project {
+  id: string;
+  title: string;
+  category: string;
+  impact: string;
+  technologies: string[];
+  demoUrl: string;
+  githubUrl?: string;
+  accent?: "violet" | "cyan" | "pink" | "teal";
+}
+```
+
+The initial data set contains exactly five featured projects. Project content remains static and local to the repository.
+
+### Components
+
+- `src/components/ProjectsSection.astro` — section wrapper, heading, and project data boundary.
+- `src/components/OrbitalGallery.svelte` — active index, orbital positions, selection events, keyboard navigation, touch gestures, and motion state.
+- `src/components/ProjectCard.svelte` — evolve the existing unused component into the Event Horizon focused mission card.
+
+Pass the typed project list from `index.astro` into `ProjectsSection.astro`, then into `OrbitalGallery.svelte`. Keep the card presentational: it receives the active project and renders normal anchors rather than owning gallery state.
+
+Use regular DOM elements and CSS transforms for the orbit. The existing PixiJS starfield remains a background layer; no second canvas is needed.
+
+## Accessibility and failure behavior
+
+- Use a semantic `section` with a heading and a labeled project navigation region.
+- Give each planet a visible or screen-reader-accessible project name.
+- Support keyboard focus, left/right selection, Enter/Space activation, and an obvious focus ring.
+- Expose the active project with `aria-selected` or an equivalent state and announce changes through a concise live region.
+- Keep all link text meaningful without relying on color or iconography.
+- Hide the GitHub button when no GitHub URL exists.
+- Hide the demo action and retain the project information if a project has no demo URL.
+- If the project list is empty, render a calm fallback message instead of an empty interactive canvas.
+- Keep all external URLs local to the data file; there is no runtime fetch or network error state.
+
+## Verification
+
+Run `pnpm build` after implementation.
+
+Perform a manual pass for:
+
+1. Desktop orbit selection by pointer, wheel, and arrow keys.
+2. Focused card content and external demo/GitHub links.
+3. Mobile swipe behavior and readable card layout.
+4. Keyboard-only navigation with visible focus styling.
+5. Reduced-motion behavior.
+6. Empty/optional-link data cases.
+7. Visual continuity with the existing starfield, black-hole cursor, About card, and Experience timeline.
+
+## Acceptance criteria
+
+- The page includes a Projects section between About and Experience.
+- Five project nodes orbit a central focus state on desktop.
+- Selecting a node reliably updates the Event Horizon mission card.
+- The card presents concise project information and a working live-demo action.
+- The interaction is usable with pointer, keyboard, and touch input.
+- Reduced-motion mode removes continuous orbit animation.
+- `pnpm build` succeeds without adding a new rendering dependency.

--- a/src/components/OrbitalGallery.svelte
+++ b/src/components/OrbitalGallery.svelte
@@ -1,0 +1,760 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+
+  import type { Project } from "../data/projects";
+  import ProjectCard from "./ProjectCard.svelte";
+
+  export let projects: Project[] = [];
+
+  type OrbitSlot = "focus" | "front-left" | "front-right" | "back-left" | "back-right" | "hidden";
+
+  interface NodeGeometry {
+    slot: OrbitSlot;
+    x: string;
+    y: string;
+    scale: number;
+    rotation: number;
+    opacity: number;
+    depth: number;
+  }
+
+  let activeIndex = 0;
+  let isReducedMotion = false;
+  let isInteracting = false;
+  let isHovering = false;
+  let isFocusedWithin = false;
+  let orbitRegion: HTMLElement | null = null;
+
+  let wheelAccumulator = 0;
+  let wheelLocked = false;
+  let wheelResetTimeout: ReturnType<typeof setTimeout> | undefined;
+  let wheelUnlockTimeout: ReturnType<typeof setTimeout> | undefined;
+  let interactionResetTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  let activePointer:
+    | {
+        id: number;
+        startX: number;
+        startY: number;
+        triggered: boolean;
+      }
+    | null = null;
+
+  const orbitGeometry: Record<Exclude<OrbitSlot, "hidden">, NodeGeometry> = {
+    focus: {
+      slot: "focus",
+      x: "0%",
+      y: "0%",
+      scale: 1,
+      rotation: 0,
+      opacity: 1,
+      depth: 5,
+    },
+    "front-left": {
+      slot: "front-left",
+      x: "-28%",
+      y: "-20%",
+      scale: 0.8,
+      rotation: -10,
+      opacity: 0.8,
+      depth: 4,
+    },
+    "front-right": {
+      slot: "front-right",
+      x: "28%",
+      y: "-20%",
+      scale: 0.8,
+      rotation: 10,
+      opacity: 0.8,
+      depth: 4,
+    },
+    "back-left": {
+      slot: "back-left",
+      x: "-37%",
+      y: "17%",
+      scale: 0.58,
+      rotation: -16,
+      opacity: 0.5,
+      depth: 2,
+    },
+    "back-right": {
+      slot: "back-right",
+      x: "37%",
+      y: "17%",
+      scale: 0.58,
+      rotation: 16,
+      opacity: 0.5,
+      depth: 2,
+    },
+  };
+
+  const hiddenGeometry: NodeGeometry = {
+    slot: "hidden",
+    x: "0%",
+    y: "24%",
+    scale: 0.42,
+    rotation: 0,
+    opacity: 0,
+    depth: 1,
+  };
+
+  function wrapIndex(index: number, total: number) {
+    return (index + total) % total;
+  }
+
+  function selectProject(index: number) {
+    if (projects.length === 0) return;
+    activeIndex = wrapIndex(index, projects.length);
+  }
+
+  function moveSelection(delta: number) {
+    selectProject(activeIndex + delta);
+  }
+
+  function getRelativeOffset(index: number, focusIndex: number, total: number) {
+    if (total <= 1) return 0;
+
+    const forward = wrapIndex(index - focusIndex, total);
+    return forward > total / 2 ? forward - total : forward;
+  }
+
+  function getNodeGeometry(index: number): NodeGeometry {
+    if (projects.length === 0) return hiddenGeometry;
+
+    const offset = getRelativeOffset(index, activeIndex, projects.length);
+
+    switch (offset) {
+      case 0:
+        return orbitGeometry.focus;
+      case -1:
+        return orbitGeometry["front-left"];
+      case 1:
+        return orbitGeometry["front-right"];
+      case -2:
+        return orbitGeometry["back-left"];
+      case 2:
+        return orbitGeometry["back-right"];
+      default:
+        return hiddenGeometry;
+    }
+  }
+
+  function getNodeStyle(index: number) {
+    const geometry = getNodeGeometry(index);
+
+    return `
+      --x: ${geometry.x};
+      --y: ${geometry.y};
+      --scale: ${geometry.scale};
+      --rotation: ${geometry.rotation}deg;
+      --opacity: ${geometry.opacity};
+      --depth: ${geometry.depth};
+    `;
+  }
+
+  function pulseInteraction(duration = 220) {
+    clearTimeout(interactionResetTimeout);
+    isInteracting = true;
+
+    interactionResetTimeout = setTimeout(() => {
+      isInteracting = false;
+    }, duration);
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (projects.length < 2) return;
+
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      moveSelection(-1);
+      pulseInteraction();
+    }
+
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      moveSelection(1);
+      pulseInteraction();
+    }
+  }
+
+  function handleWheel(event: WheelEvent) {
+    if (projects.length < 2) return;
+
+    const dominantDelta = Math.abs(event.deltaX) > Math.abs(event.deltaY) ? event.deltaX : event.deltaY;
+
+    if (Math.abs(dominantDelta) < 6) return;
+
+    clearTimeout(wheelResetTimeout);
+    wheelResetTimeout = setTimeout(() => {
+      wheelAccumulator = 0;
+    }, 140);
+
+    if (wheelLocked) return;
+
+    wheelAccumulator += dominantDelta;
+
+    if (Math.abs(wheelAccumulator) < 28) return;
+
+    moveSelection(wheelAccumulator > 0 ? 1 : -1);
+    wheelAccumulator = 0;
+    wheelLocked = true;
+    pulseInteraction(260);
+
+    clearTimeout(wheelUnlockTimeout);
+    wheelUnlockTimeout = setTimeout(() => {
+      wheelLocked = false;
+    }, 260);
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    if (projects.length < 2 || !event.isPrimary) return;
+    if (event.pointerType === "mouse" && event.button !== 0) return;
+
+    activePointer = {
+      id: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      triggered: false,
+    };
+
+    isInteracting = true;
+    orbitRegion?.setPointerCapture(event.pointerId);
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!activePointer || event.pointerId !== activePointer.id || activePointer.triggered) return;
+
+    const deltaX = event.clientX - activePointer.startX;
+    const deltaY = event.clientY - activePointer.startY;
+
+    if (Math.abs(deltaX) < 40 || Math.abs(deltaX) <= Math.abs(deltaY)) return;
+
+    moveSelection(deltaX > 0 ? -1 : 1);
+    activePointer.triggered = true;
+    pulseInteraction(260);
+  }
+
+  function finishPointerInteraction(pointerId?: number) {
+    if (!activePointer) return;
+    if (typeof pointerId === "number" && pointerId !== activePointer.id) return;
+
+    if (orbitRegion?.hasPointerCapture(activePointer.id)) {
+      orbitRegion.releasePointerCapture(activePointer.id);
+    }
+
+    activePointer = null;
+    pulseInteraction(160);
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    finishPointerInteraction(event.pointerId);
+  }
+
+  function handlePointerCancel(event: PointerEvent) {
+    finishPointerInteraction(event.pointerId);
+  }
+
+  function handlePointerEnter() {
+    isHovering = true;
+  }
+
+  function handlePointerLeave() {
+    isHovering = false;
+
+    if (!activePointer) {
+      clearTimeout(interactionResetTimeout);
+      isInteracting = false;
+    }
+  }
+
+  function handleFocusIn() {
+    isFocusedWithin = true;
+  }
+
+  function handleFocusOut(event: FocusEvent) {
+    const nextTarget = event.relatedTarget as Node | null;
+
+    if (orbitRegion && nextTarget && orbitRegion.contains(nextTarget)) return;
+
+    isFocusedWithin = false;
+  }
+
+  $: if (projects.length === 0) {
+    activeIndex = 0;
+  } else {
+    activeIndex = wrapIndex(activeIndex, projects.length);
+  }
+
+  $: activeProject = projects[activeIndex];
+  $: liveAnnouncement = activeProject ? `Selected project: ${activeProject.title}` : "";
+  $: isIdleMotionPaused = isReducedMotion || isHovering || isFocusedWithin || isInteracting;
+
+  onMount(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const syncReducedMotion = (event: MediaQueryList | MediaQueryListEvent) => {
+      isReducedMotion = event.matches;
+    };
+
+    syncReducedMotion(mediaQuery);
+
+    if ("addEventListener" in mediaQuery) {
+      mediaQuery.addEventListener("change", syncReducedMotion);
+    } else {
+      mediaQuery.addListener(syncReducedMotion);
+    }
+
+    if (orbitRegion) {
+      orbitRegion.addEventListener("wheel", handleWheel, { passive: true });
+      orbitRegion.addEventListener("pointerdown", handlePointerDown);
+      orbitRegion.addEventListener("pointermove", handlePointerMove);
+      orbitRegion.addEventListener("pointerup", handlePointerUp);
+      orbitRegion.addEventListener("pointercancel", handlePointerCancel);
+      orbitRegion.addEventListener("pointerenter", handlePointerEnter);
+      orbitRegion.addEventListener("pointerleave", handlePointerLeave);
+      orbitRegion.addEventListener("focusin", handleFocusIn);
+      orbitRegion.addEventListener("focusout", handleFocusOut);
+    }
+
+    return () => {
+      if ("removeEventListener" in mediaQuery) {
+        mediaQuery.removeEventListener("change", syncReducedMotion);
+      } else {
+        mediaQuery.removeListener(syncReducedMotion);
+      }
+
+      if (orbitRegion) {
+        orbitRegion.removeEventListener("wheel", handleWheel);
+        orbitRegion.removeEventListener("pointerdown", handlePointerDown);
+        orbitRegion.removeEventListener("pointermove", handlePointerMove);
+        orbitRegion.removeEventListener("pointerup", handlePointerUp);
+        orbitRegion.removeEventListener("pointercancel", handlePointerCancel);
+        orbitRegion.removeEventListener("pointerenter", handlePointerEnter);
+        orbitRegion.removeEventListener("pointerleave", handlePointerLeave);
+        orbitRegion.removeEventListener("focusin", handleFocusIn);
+        orbitRegion.removeEventListener("focusout", handleFocusOut);
+      }
+
+      clearTimeout(wheelResetTimeout);
+      clearTimeout(wheelUnlockTimeout);
+      clearTimeout(interactionResetTimeout);
+    };
+  });
+
+  onDestroy(() => {
+    clearTimeout(wheelResetTimeout);
+    clearTimeout(wheelUnlockTimeout);
+    clearTimeout(interactionResetTimeout);
+  });
+</script>
+
+{#if projects.length === 0}
+  <section class="orbital-gallery orbital-gallery--empty" aria-label="Orbital project gallery">
+    <p class="orbital-gallery__empty-copy">No missions have been added yet.</p>
+  </section>
+{:else}
+  <section class="orbital-gallery" aria-label="Orbital project gallery" on:keydown={handleKeydown}>
+    <p class="orbital-gallery__sr-only" aria-live="polite" aria-atomic="true">{liveAnnouncement}</p>
+
+    <div
+      class="orbital-gallery__stage"
+      bind:this={orbitRegion}
+      data-paused={isIdleMotionPaused}
+      tabindex="0"
+      role="group"
+      aria-label="Project orbit navigation"
+    >
+      <div class="orbital-gallery__rings" aria-hidden="true">
+        <span class="orbital-gallery__ring orbital-gallery__ring--outer"></span>
+        <span class="orbital-gallery__ring orbital-gallery__ring--inner"></span>
+      </div>
+
+      <div class="orbital-gallery__well" aria-hidden="true">
+        <span class="orbital-gallery__well-core"></span>
+        <span class="orbital-gallery__well-halo"></span>
+        <span class="orbital-gallery__well-label">Event Horizon</span>
+      </div>
+
+      {#each projects as project, index}
+        {@const geometry = getNodeGeometry(index)}
+        {@const isActive = index === activeIndex}
+        <button
+          type="button"
+          class:selected={isActive}
+          class="mission-node"
+          data-slot={geometry.slot}
+          style={getNodeStyle(index)}
+          aria-label={`Select project: ${project.title}`}
+          aria-pressed={isActive}
+          aria-controls="orbital-gallery-active-card"
+          title={project.title}
+          on:click={() => {
+            selectProject(index);
+            pulseInteraction();
+          }}
+        >
+          <span class="mission-node__index">Mission {String(index + 1).padStart(2, "0")}</span>
+          <span class="mission-node__title">{project.title}</span>
+        </button>
+      {/each}
+    </div>
+
+    <div class="orbital-gallery__card" id="orbital-gallery-active-card">
+      <ProjectCard project={activeProject} missionNumber={activeIndex + 1} missionTotal={projects.length} />
+    </div>
+  </section>
+{/if}
+
+<style>
+  .orbital-gallery {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(18rem, 1.05fr);
+    gap: 1.5rem;
+    align-items: stretch;
+  }
+
+  .orbital-gallery--empty {
+    grid-template-columns: 1fr;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 1.75rem;
+    background: linear-gradient(180deg, rgba(11, 10, 22, 0.92), rgba(5, 7, 15, 0.96));
+    padding: 1.75rem;
+    color: rgba(226, 232, 240, 0.82);
+  }
+
+  .orbital-gallery__empty-copy {
+    margin: 0;
+    line-height: 1.6;
+  }
+
+  .orbital-gallery__stage {
+    position: relative;
+    min-height: 31rem;
+    overflow: hidden;
+    border: 1px solid rgba(103, 232, 249, 0.18);
+    border-radius: 2rem;
+    background:
+      radial-gradient(circle at 50% 46%, rgba(192, 132, 252, 0.18), transparent 18%),
+      radial-gradient(circle at 18% 18%, rgba(34, 211, 238, 0.12), transparent 26%),
+      radial-gradient(circle at 82% 78%, rgba(244, 114, 182, 0.12), transparent 24%),
+      linear-gradient(180deg, rgba(7, 10, 19, 0.94), rgba(2, 6, 23, 0.98));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 1.25rem 3rem rgba(2, 6, 23, 0.45);
+    isolation: isolate;
+    outline: none;
+    touch-action: pan-y pinch-zoom;
+  }
+
+  .orbital-gallery__stage:focus-visible {
+    box-shadow:
+      0 0 0 3px rgba(103, 232, 249, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 1.25rem 3rem rgba(2, 6, 23, 0.45);
+  }
+
+  .orbital-gallery__stage::before {
+    content: "";
+    position: absolute;
+    inset: 1.1rem;
+    border-radius: 1.45rem;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    pointer-events: none;
+  }
+
+  .orbital-gallery__rings,
+  .orbital-gallery__well-halo {
+    animation-play-state: running;
+  }
+
+  .orbital-gallery__stage[data-paused="true"] .orbital-gallery__rings,
+  .orbital-gallery__stage[data-paused="true"] .orbital-gallery__well-halo {
+    animation-play-state: paused;
+  }
+
+  .orbital-gallery__rings {
+    position: absolute;
+    inset: 0;
+    animation: orbital-drift 18s linear infinite;
+    pointer-events: none;
+  }
+
+  .orbital-gallery__ring {
+    position: absolute;
+    left: 50%;
+    top: 47%;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    transform: translate(-50%, -50%);
+    box-shadow: 0 0 0 1px rgba(103, 232, 249, 0.04);
+  }
+
+  .orbital-gallery__ring--outer {
+    width: min(88%, 28rem);
+    height: 14rem;
+  }
+
+  .orbital-gallery__ring--inner {
+    width: min(58%, 18rem);
+    height: 9rem;
+    border-color: rgba(167, 139, 250, 0.18);
+    transform: translate(-50%, -50%) rotate(-12deg);
+  }
+
+  .orbital-gallery__well {
+    position: absolute;
+    left: 50%;
+    top: 47%;
+    width: 10rem;
+    height: 10rem;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+
+  .orbital-gallery__well-core,
+  .orbital-gallery__well-halo {
+    position: absolute;
+    inset: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 999px;
+  }
+
+  .orbital-gallery__well-core {
+    width: 4.75rem;
+    height: 4.75rem;
+    background:
+      radial-gradient(circle at 35% 30%, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.98) 54%),
+      radial-gradient(circle at 62% 62%, rgba(244, 114, 182, 0.18), transparent 68%);
+    box-shadow:
+      0 0 0 1px rgba(34, 211, 238, 0.18),
+      0 0 2.5rem rgba(168, 85, 247, 0.24),
+      inset 0 0.2rem 1rem rgba(255, 255, 255, 0.06);
+  }
+
+  .orbital-gallery__well-halo {
+    width: 9rem;
+    height: 9rem;
+    background:
+      radial-gradient(circle, rgba(168, 85, 247, 0.18) 0%, rgba(168, 85, 247, 0.08) 34%, transparent 68%);
+    filter: blur(4px);
+    animation: orbital-drift 14s linear infinite reverse;
+  }
+
+  .orbital-gallery__well-label {
+    position: absolute;
+    left: 50%;
+    bottom: -0.3rem;
+    transform: translateX(-50%);
+    border-radius: 999px;
+    border: 1px solid rgba(34, 211, 238, 0.2);
+    background: rgba(7, 10, 19, 0.8);
+    padding: 0.4rem 0.8rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(244, 114, 182, 0.92);
+    white-space: nowrap;
+  }
+
+  .mission-node {
+    position: absolute;
+    left: calc(50% + var(--x));
+    top: calc(47% + var(--y));
+    z-index: var(--depth);
+    display: grid;
+    gap: 0.3rem;
+    width: min(11rem, calc(100% - 2.5rem));
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    border-radius: 1.2rem;
+    background: rgba(15, 23, 42, 0.78);
+    padding: 0.78rem 0.9rem;
+    color: rgba(248, 250, 252, 0.9);
+    text-align: left;
+    cursor: pointer;
+    opacity: var(--opacity);
+    transform: translate(-50%, -50%) scale(var(--scale)) rotate(var(--rotation));
+    box-shadow:
+      0 1rem 2rem rgba(2, 6, 23, 0.3),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    transition:
+      left 240ms ease,
+      top 240ms ease,
+      transform 240ms ease,
+      opacity 180ms ease,
+      box-shadow 180ms ease,
+      border-color 180ms ease,
+      background-color 180ms ease;
+  }
+
+  .mission-node:hover {
+    border-color: rgba(103, 232, 249, 0.48);
+    box-shadow:
+      0 1.2rem 2.4rem rgba(2, 6, 23, 0.36),
+      0 0 0 1px rgba(103, 232, 249, 0.1);
+  }
+
+  .mission-node:focus-visible {
+    outline: 3px solid rgba(103, 232, 249, 0.9);
+    outline-offset: 3px;
+  }
+
+  .mission-node.selected {
+    border-color: rgba(196, 181, 253, 0.62);
+    background:
+      linear-gradient(135deg, rgba(34, 211, 238, 0.16), rgba(168, 85, 247, 0.2)),
+      rgba(15, 23, 42, 0.92);
+    box-shadow:
+      0 1.5rem 3rem rgba(2, 6, 23, 0.42),
+      0 0 0 1px rgba(196, 181, 253, 0.14),
+      0 0 2.2rem rgba(168, 85, 247, 0.18);
+  }
+
+  .mission-node[data-slot="hidden"] {
+    pointer-events: none;
+  }
+
+  .mission-node__index {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: rgba(103, 232, 249, 0.88);
+  }
+
+  .mission-node__title {
+    display: block;
+    overflow: hidden;
+    font-size: 0.96rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .orbital-gallery__card {
+    min-width: 0;
+    align-self: center;
+  }
+
+  .orbital-gallery__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @keyframes orbital-drift {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (max-width: 960px) {
+    .orbital-gallery {
+      grid-template-columns: 1fr;
+    }
+
+    .orbital-gallery__card {
+      order: -1;
+    }
+
+    .orbital-gallery__stage {
+      min-height: 15.5rem;
+    }
+
+    .orbital-gallery__rings {
+      display: none;
+    }
+
+    .orbital-gallery__well {
+      width: 7rem;
+      height: 7rem;
+      opacity: 0.72;
+    }
+
+    .orbital-gallery__well-core {
+      width: 3.5rem;
+      height: 3.5rem;
+    }
+
+    .orbital-gallery__well-halo {
+      width: 6.5rem;
+      height: 6.5rem;
+    }
+
+    .orbital-gallery__well-label {
+      display: none;
+    }
+
+    .mission-node {
+      width: min(9rem, calc(100% - 1.75rem));
+      padding: 0.7rem 0.8rem;
+    }
+
+    .mission-node[data-slot="focus"] {
+      --x: 0%;
+      --y: 19%;
+      --scale: 1;
+    }
+
+    .mission-node[data-slot="front-left"] {
+      --x: -29%;
+      --y: 19%;
+      --scale: 0.58;
+      --rotation: 0deg;
+    }
+
+    .mission-node[data-slot="front-right"] {
+      --x: 29%;
+      --y: 19%;
+      --scale: 0.58;
+      --rotation: 0deg;
+    }
+
+    .mission-node[data-slot="back-left"] {
+      --x: -41%;
+      --y: 21%;
+      --scale: 0.34;
+      --rotation: 0deg;
+      --opacity: 0.42;
+    }
+
+    .mission-node[data-slot="back-right"] {
+      --x: 41%;
+      --y: 21%;
+      --scale: 0.34;
+      --rotation: 0deg;
+      --opacity: 0.42;
+    }
+
+    .mission-node[data-slot="back-left"] .mission-node__title,
+    .mission-node[data-slot="back-right"] .mission-node__title {
+      opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .orbital-gallery__rings,
+    .orbital-gallery__well-halo {
+      animation: none;
+    }
+
+    .mission-node,
+    .orbital-gallery__stage {
+      transition:
+        opacity 140ms ease,
+        box-shadow 140ms ease,
+        border-color 140ms ease,
+        background-color 140ms ease;
+    }
+  }
+</style>

--- a/src/components/OrbitalGallery.svelte
+++ b/src/components/OrbitalGallery.svelte
@@ -1,3 +1,6 @@
+<script context="module" lang="ts">
+  let galleryInstanceCount = 0;
+</script>
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
 
@@ -23,7 +26,10 @@
   let isInteracting = false;
   let isHovering = false;
   let isFocusedWithin = false;
+  let galleryRegion: HTMLElement | null = null;
   let orbitRegion: HTMLElement | null = null;
+
+  const activeCardId = `orbital-gallery-${++galleryInstanceCount}-active-card`;
 
   let wheelAccumulator = 0;
   let wheelLocked = false;
@@ -274,7 +280,7 @@
   function handleFocusOut(event: FocusEvent) {
     const nextTarget = event.relatedTarget as Node | null;
 
-    if (orbitRegion && nextTarget && orbitRegion.contains(nextTarget)) return;
+    if (galleryRegion && nextTarget && galleryRegion.contains(nextTarget)) return;
 
     isFocusedWithin = false;
   }
@@ -311,8 +317,6 @@
       orbitRegion.addEventListener("pointercancel", handlePointerCancel);
       orbitRegion.addEventListener("pointerenter", handlePointerEnter);
       orbitRegion.addEventListener("pointerleave", handlePointerLeave);
-      orbitRegion.addEventListener("focusin", handleFocusIn);
-      orbitRegion.addEventListener("focusout", handleFocusOut);
     }
 
     return () => {
@@ -330,8 +334,6 @@
         orbitRegion.removeEventListener("pointercancel", handlePointerCancel);
         orbitRegion.removeEventListener("pointerenter", handlePointerEnter);
         orbitRegion.removeEventListener("pointerleave", handlePointerLeave);
-        orbitRegion.removeEventListener("focusin", handleFocusIn);
-        orbitRegion.removeEventListener("focusout", handleFocusOut);
       }
 
       clearTimeout(wheelResetTimeout);
@@ -352,7 +354,14 @@
     <p class="orbital-gallery__empty-copy">No missions have been added yet.</p>
   </section>
 {:else}
-  <section class="orbital-gallery" aria-label="Orbital project gallery" on:keydown={handleKeydown}>
+  <section
+    class="orbital-gallery"
+    bind:this={galleryRegion}
+    aria-label="Orbital project gallery"
+    on:keydown={handleKeydown}
+    on:focusin={handleFocusIn}
+    on:focusout={handleFocusOut}
+  >
     <p class="orbital-gallery__sr-only" aria-live="polite" aria-atomic="true">{liveAnnouncement}</p>
 
     <div
@@ -377,6 +386,7 @@
       {#each projects as project, index}
         {@const geometry = getNodeGeometry(index)}
         {@const isActive = index === activeIndex}
+        {@const isHidden = geometry.slot === "hidden"}
         <button
           type="button"
           class:selected={isActive}
@@ -385,7 +395,11 @@
           style={getNodeStyle(index)}
           aria-label={`Select project: ${project.title}`}
           aria-pressed={isActive}
-          aria-controls="orbital-gallery-active-card"
+          aria-controls={activeCardId}
+          aria-hidden={isHidden ? "true" : undefined}
+          tabindex={isHidden ? -1 : undefined}
+          inert={isHidden}
+          disabled={isHidden}
           title={project.title}
           on:click={() => {
             selectProject(index);
@@ -398,7 +412,7 @@
       {/each}
     </div>
 
-    <div class="orbital-gallery__card" id="orbital-gallery-active-card">
+    <div class="orbital-gallery__card" id={activeCardId}>
       <ProjectCard project={activeProject} missionNumber={activeIndex + 1} missionTotal={projects.length} />
     </div>
   </section>

--- a/src/components/ProjectCard.svelte
+++ b/src/components/ProjectCard.svelte
@@ -1,79 +1,263 @@
-<script>
-  export let title = '';
-  export let description = '';
-  export let imageUrl = '';
-  export let projectUrl = '';
+<script lang="ts">
+  import type { Project } from "../data/projects";
+
+  export let project: Project;
+  export let missionNumber = 1;
+  export let missionTotal = 5;
+
+  $: missionLabel = `Mission ${String(missionNumber).padStart(2, "0")} / ${String(missionTotal).padStart(2, "0")}`;
+  $: techTags = project.technologies.slice(0, 4);
+  $: accent = project.accent ?? "violet";
 </script>
 
-<div class="project-card">
-  <img src={imageUrl} alt={title} class="project-image" />
-  <div class="project-content">
-    <h3 class="project-title">{title}</h3>
-    <p class="project-description">{description}</p>
-    <a href={projectUrl} class="project-link" target="_blank" rel="noopener noreferrer">
-      View Project
-    </a>
+<article class="mission-card" data-accent={accent} aria-labelledby={`mission-title-${project.id}`}>
+  <div class="mission-card__shell">
+    <div class="mission-card__header">
+      <p class="mission-card__eyebrow">{missionLabel}</p>
+      <p class="mission-card__category">{project.category}</p>
+    </div>
+
+    <div class="mission-card__title-row">
+      <h3 id={`mission-title-${project.id}`} class="mission-card__title">{project.title}</h3>
+      <span class="mission-card__sigil">Event Horizon</span>
+    </div>
+
+    <p class="mission-card__impact">{project.impact}</p>
+
+    {#if techTags.length}
+      <ul class="mission-card__tech-list" aria-label="Technologies used">
+        {#each techTags as technology}
+          <li class="mission-card__tech">{technology}</li>
+        {/each}
+      </ul>
+    {/if}
+
+    <div class="mission-card__actions" aria-label="Project links">
+      {#if project.demoUrl}
+        <a class="mission-card__link mission-card__link--demo" href={project.demoUrl} target="_blank" rel="noopener noreferrer">
+          Launch Demo
+        </a>
+      {/if}
+
+      {#if project.githubUrl}
+        <a class="mission-card__link mission-card__link--github" href={project.githubUrl} target="_blank" rel="noopener noreferrer">
+          GitHub
+        </a>
+      {/if}
+    </div>
   </div>
-</div>
+</article>
 
 <style>
-  .project-card {
-    background-color: rgba(20, 20, 50, 0.9);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 15px;
+  .mission-card {
+    position: relative;
+    isolation: isolate;
     overflow: hidden;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border: 1px solid rgba(167, 139, 250, 0.28);
+    border-radius: 1.5rem;
+    background:
+      radial-gradient(circle at top, rgba(168, 85, 247, 0.22), transparent 38%),
+      radial-gradient(circle at 82% 18%, rgba(34, 211, 238, 0.12), transparent 24%),
+      linear-gradient(180deg, rgba(11, 10, 22, 0.98), rgba(5, 7, 15, 0.98));
+    box-shadow:
+      0 1.5rem 3rem rgba(2, 6, 23, 0.48),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    color: rgba(248, 250, 252, 0.94);
+    transition:
+      transform 220ms ease,
+      box-shadow 220ms ease,
+      border-color 220ms ease;
+  }
+
+  .mission-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(circle at 50% 18%, rgba(15, 23, 42, 0.75), transparent 16%),
+      radial-gradient(circle at 50% 18%, rgba(192, 132, 252, 0.26), transparent 28%),
+      radial-gradient(circle at 50% 18%, rgba(34, 211, 238, 0.12), transparent 42%);
+    opacity: 0.95;
+    pointer-events: none;
+  }
+
+  .mission-card::after {
+    content: "";
+    position: absolute;
+    inset: 1rem;
+    border-radius: 1.1rem;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.06);
+    pointer-events: none;
+  }
+
+  .mission-card:hover {
+    transform: translateY(-0.2rem);
+    border-color: rgba(196, 181, 253, 0.55);
+    box-shadow:
+      0 1.8rem 3.75rem rgba(2, 6, 23, 0.56),
+      0 0 0 1px rgba(168, 85, 247, 0.08),
+      0 0 2.5rem rgba(168, 85, 247, 0.14),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  .mission-card__shell {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem;
+  }
+
+  .mission-card__header {
     display: flex;
-    flex-direction: column;
-    backdrop-filter: blur(5px);
-  }
-
-  .project-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 20px rgba(255, 255, 255, 0.2);
-    border-color: rgba(255, 255, 255, 0.5);
-  }
-
-  .project-image {
-    width: 100%;
-    height: 200px;
-    object-fit: cover;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  }
-
-  .project-content {
-    padding: 20px;
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    align-items: center;
     justify-content: space-between;
+    gap: 0.75rem;
   }
 
-  .project-title {
-    font-size: 1.5rem;
-    color: #fff;
-    margin-bottom: 10px;
+  .mission-card__eyebrow {
+    margin: 0;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(103, 232, 249, 0.92);
   }
 
-  .project-description {
-    font-size: 1rem;
-    color: #ccc;
-    margin-bottom: 15px;
-    flex-grow: 1;
+  .mission-card__category {
+    margin: 0;
+    font-size: 0.875rem;
+    color: rgba(196, 181, 253, 0.82);
   }
 
-  .project-link {
-    display: inline-block;
-    padding: 8px 15px;
-    background-color: #4a00e0;
-    color: #fff;
+  .mission-card__title-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .mission-card__title {
+    margin: 0;
+    max-width: 20ch;
+    font-size: clamp(1.35rem, 2vw, 1.8rem);
+    line-height: 1.06;
+    letter-spacing: -0.03em;
+    color: #f8fafc;
+  }
+
+  .mission-card__sigil {
+    flex: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border-radius: 999px;
+    border: 1px solid rgba(34, 211, 238, 0.25);
+    background: rgba(15, 23, 42, 0.72);
+    padding: 0.38rem 0.7rem;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(244, 114, 182, 0.95);
+    box-shadow: inset 0 0 0 1px rgba(244, 114, 182, 0.08);
+  }
+
+  .mission-card__impact {
+    margin: 0;
+    max-width: 60ch;
+    color: rgba(226, 232, 240, 0.86);
+    line-height: 1.65;
+  }
+
+  .mission-card__tech-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.625rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .mission-card__tech {
+    border-radius: 999px;
+    border: 1px solid rgba(34, 211, 238, 0.18);
+    background: rgba(15, 23, 42, 0.62);
+    padding: 0.42rem 0.75rem;
+    font-size: 0.8rem;
+    color: rgba(224, 231, 255, 0.88);
+  }
+
+  .mission-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding-top: 0.2rem;
+  }
+
+  .mission-card__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    padding: 0.65rem 1rem;
+    font-size: 0.92rem;
+    font-weight: 700;
     text-decoration: none;
-    border-radius: 5px;
-    transition: background-color 0.3s ease;
-    align-self: flex-start;
+    transition:
+      transform 180ms ease,
+      border-color 180ms ease,
+      background-color 180ms ease,
+      color 180ms ease,
+      box-shadow 180ms ease;
   }
 
-  .project-link:hover {
-    background-color: #6D18E2;
+  .mission-card__link--demo {
+    background: linear-gradient(135deg, rgba(34, 211, 238, 0.18), rgba(168, 85, 247, 0.34));
+    border-color: rgba(103, 232, 249, 0.26);
+    color: #f8fafc;
+    box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.24);
+  }
+
+  .mission-card__link--github {
+    background: rgba(15, 23, 42, 0.76);
+    border-color: rgba(244, 114, 182, 0.22);
+    color: rgba(248, 250, 252, 0.92);
+  }
+
+  .mission-card__link:hover {
+    transform: translateY(-1px);
+  }
+
+  .mission-card__link--demo:hover {
+    border-color: rgba(103, 232, 249, 0.44);
+    box-shadow: 0 0.95rem 1.75rem rgba(15, 23, 42, 0.28), 0 0 0 1px rgba(103, 232, 249, 0.12);
+  }
+
+  .mission-card__link--github:hover {
+    border-color: rgba(244, 114, 182, 0.4);
+    color: #ffffff;
+  }
+
+  .mission-card__link:focus-visible {
+    outline: 3px solid rgba(103, 232, 249, 0.94);
+    outline-offset: 3px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mission-card,
+    .mission-card__link {
+      transition: none;
+    }
+
+    .mission-card:hover,
+    .mission-card__link:hover {
+      transform: none;
+    }
   }
 </style>

--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -1,0 +1,59 @@
+---
+import OrbitalGallery from "./OrbitalGallery.svelte";
+import type { Project } from "../data/projects";
+
+export interface Props {
+  projects: Project[];
+}
+
+const { projects } = Astro.props;
+---
+
+<section id="projects" class="projects-section" aria-labelledby="projects-title">
+  <p class="projects-kicker">Mission archive</p>
+  <h2 id="projects-title" class="projects-title">Projects</h2>
+  <p class="projects-intro">Select a mission and launch into the work.</p>
+  <OrbitalGallery client:load projects={projects} />
+</section>
+
+<style>
+  .projects-section {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 6rem 2rem 2rem;
+    position: relative;
+    z-index: 3;
+  }
+
+  .projects-kicker {
+    margin: 0 0 0.65rem;
+    color: rgba(103, 232, 249, 0.86);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-align: center;
+    text-transform: uppercase;
+  }
+
+  .projects-title {
+    margin: 0 0 0.85rem;
+    color: #fff;
+    font-family: "Sora", sans-serif;
+    font-size: 3.5rem;
+    text-align: center;
+  }
+
+  .projects-intro {
+    margin: 0 auto 2.5rem;
+    color: rgba(226, 232, 240, 0.76);
+    font-size: 1rem;
+    line-height: 1.6;
+    text-align: center;
+  }
+
+  @media (max-width: 767px) {
+    .projects-title {
+      font-size: 2.5rem;
+    }
+  }
+</style>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,58 @@
+export interface Project {
+  id: string;
+  title: string;
+  category: string;
+  impact: string;
+  technologies: string[];
+  demoUrl: string;
+  githubUrl?: string;
+  accent?: "violet" | "cyan" | "pink" | "teal";
+}
+
+export const projects: Project[] = [
+  {
+    id: "sample-orbital-relay",
+    title: "Sample Project 1 — Orbital Relay",
+    category: "Sample / Demo",
+    impact: "Placeholder case study for the gallery data boundary; replace with a real project summary later.",
+    technologies: ["Astro", "TypeScript", "Tailwind CSS"],
+    demoUrl: "https://example.com/orbital-relay",
+    accent: "violet",
+  },
+  {
+    id: "sample-lunar-map",
+    title: "Sample Project 2 — Lunar Map",
+    category: "Sample / Demo",
+    impact: "Placeholder for an interactive showcase entry with a clear, easy-to-edit demo link.",
+    technologies: ["Svelte", "Motion", "SVG"],
+    demoUrl: "https://example.com/lunar-map",
+    accent: "cyan",
+  },
+  {
+    id: "sample-starlane-archive",
+    title: "Sample Project 3 — Starlane Archive",
+    category: "Sample / Demo",
+    impact: "Placeholder project used to validate multi-card gallery layouts and content rendering.",
+    technologies: ["Astro", "Markdown", "Design Systems"],
+    demoUrl: "https://example.com/starlane-archive",
+    accent: "pink",
+  },
+  {
+    id: "sample-aurora-console",
+    title: "Sample Project 4 — Aurora Console",
+    category: "Sample / Demo",
+    impact: "Placeholder for a dashboard-style project that later tasks can replace with real content.",
+    technologies: ["TypeScript", "Data Viz", "UI Engineering"],
+    demoUrl: "https://example.com/aurora-console",
+    accent: "teal",
+  },
+  {
+    id: "sample-vector-harbor",
+    title: "Sample Project 5 — Vector Harbor",
+    category: "Sample / Demo",
+    impact: "Placeholder entry reserved for the final gallery slot and future user-provided project details.",
+    technologies: ["Accessibility", "Animation", "Performance"],
+    demoUrl: "https://example.com/vector-harbor",
+    accent: "violet",
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,8 +4,10 @@ import StarField from "../components/StarField.astro";
 import HeroSection from "../components/HeroSection.astro";
 import SocialLinks from "../components/SocialLinks.astro";
 import AboutSection from "../components/AboutSection.astro";
+import ProjectsSection from "../components/ProjectsSection.astro";
 import ExperienceSection from "../components/ExperienceSection.astro";
 import { jobs } from "../data/jobs";
+import { projects } from "../data/projects";
 ---
 
 <!doctype html>
@@ -44,6 +46,7 @@ import { jobs } from "../data/jobs";
 		<HeroSection />
 		<SocialLinks />
 		<AboutSection />
+		<ProjectsSection projects={projects} />
 		<ExperienceSection jobs={jobs} />
 	</body>
 </html>


### PR DESCRIPTION
## Summary

- Add a five-project orbital gallery section after About and before Experience.
- Add Event Horizon mission-card styling to match the black-hole visual theme.
- Add keyboard, wheel, pointer/touch, reduced-motion, focus-pause, and empty-state handling.
- Keep the existing starfield/canvas composition and use the current Astro/Svelte architecture.

## Validation

- `pnpm build` passes.
- Final branch diff check is clean.
- Independent task and branch reviews found no blocking issues.

## Before merging

The project entries intentionally use fake `example.com` demo/GitHub URLs and sample copy. Replace the contents of `src/data/projects.ts` with your real project names, descriptions, tags, and links.